### PR TITLE
Allow different weights and styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,28 @@ There is also a `font` tag that will return the raw CSS:
     {% font_css "Pathway Extreme" %}
 ```
 
+Custom font weights are available by specifying the font weights in the URL. The easy way to do this is visit a font page, for example [Robot](https://fonts.google.com/specimen/Roboto) and then selecting the weights and styles you'd like. Then click on `Selected Families` and copy the font definition in.
+
+For example Google will suggest embedding the font using this URL:
+
+```html
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100;0,700;0,900;1,700&display=swap" rel="stylesheet">
+```
+
+Roboto with italic in weights 100, 700, 900. To use this in Django you would specify:
+
+```python
+GOOGLE_FONTS = ["Roboto:ital,wght@0,100;0,700;1,700"]
+```
+
+And you would reference it in a stylesheet:
+
+```html
+<link rel="stylesheet" href="{% static 'fonts/roboto:ital,wght@0,100;0,700;1,700.css' %}">
+```
+
 #### Optional settings
 
 By default `django-google-fonts` will store fonts in the first directory specified in `STATICFILES_DIRS`. That might not be where you want, so you can set a `GOOGLE_FONTS_DIR` setting if you'd like it be somewhere else:

--- a/django_google_fonts/apps.py
+++ b/django_google_fonts/apps.py
@@ -16,7 +16,7 @@ user_agent = getattr(
     "GOOGLE_FONTS_USER_AGENT",
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36",
 )
-css_url = "https://fonts.googleapis.com/css"
+css_url = "https://fonts.googleapis.com/css2"
 css_prefix = "https://fonts.gstatic.com/s/"
 log_prefix = "django_google_fonts"
 # Requests timeout in seconds.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ line-length = 100
 
 [project]
 name = "django_google_fonts"
-version = "0.0.2"
+version = "0.0.3"
 authors = [
   { name="Andy McKay", email="andy@mckay.pub" },
 ]


### PR DESCRIPTION
By using the css2 endpoint, you can now embed different weights and styles

The syntax is a bit odd, but it's the code that the google page generates for you here:

<img width="1215" alt="Screenshot 2023-07-06 at 2 58 47 PM" src="https://github.com/andymckay/django-google-fonts/assets/74699/4fa70dcb-d245-4b01-816c-1eb6ef4f5f3b">
