### PR TITLE
Hash the incoming URL

### DIFF
--- a/django_google_fonts/apps.py
+++ b/django_google_fonts/apps.py
@@ -1,8 +1,11 @@
 import logging
 import os
 
+import hashlib
 import requests
 import tinycss2
+import json
+from tinycss2.ast import Comment
 from django.apps import AppConfig
 from django.conf import settings
 
@@ -19,19 +22,25 @@ user_agent = getattr(
 css_url = "https://fonts.googleapis.com/css2"
 css_prefix = "https://fonts.gstatic.com/s/"
 log_prefix = "django_google_fonts"
+json_prefix = "Django-Google-Font: "
 # Requests timeout in seconds.
 timeout = 10
 fonts = []
 
 
 class Font:
-    __slots__ = ["name", "dest", "slug", "dest_css"]
+    __slots__ = ["name", "dest", "slug", "dest_css", "rest"]
 
     def __init__(self, name, dest):
         self.name = name
-        self.slug = self.name.replace(" ", "").lower()
+        lowered = name.replace(" ", "").lower()
+        if ":" in lowered:
+            self.slug, rest = lowered.split(":")
+            self.rest = {"original": rest, "hash": hashlib.shake_256(rest.encode("utf-8")).hexdigest(8)}
+        else:
+            self.slug = lowered
+        self.dest_css = os.path.join(dest, f"{self.slug}-{self.rest['hash']}.css")
         self.dest = dest
-        self.dest_css = os.path.join(dest, self.slug + ".css")
 
     def cached(self):
         return os.path.exists(self.dest_css)
@@ -79,11 +88,20 @@ class Font:
                         with open(dest, "wb") as f:
                             f.write(res.content)
 
+                        # JSON inside CSS. It's the future.
+                        metadata = json.dumps({
+                            "name": self.name,
+                            "slug": self.slug,
+                            "rest": self.rest
+                        })
+                        comment = Comment(0, 0, f"{json_prefix}{metadata}")
+
                         # STATIC_URL must have a trailing slash.
                         path = getattr(settings, "GOOGLE_FONTS_URL", f"{settings.STATIC_URL}fonts/")
                         line.representation = line.representation.replace(
                             "https://fonts.gstatic.com/s/", path
                         )
+                        output_css.insert(0, comment)
                         output_css.append(rule)
 
         with open(self.dest_css, "w", encoding="utf-8") as f:
@@ -131,3 +149,14 @@ class DjangoGoogleFontsConfig(AppConfig):
             self.fonts.append(font)
 
         return True
+
+    def iterate(self):
+        for font in self.fonts:
+            with open(font.dest_css, "r", encoding="utf-8") as f:
+                parsed = tinycss2.parse_stylesheet(f.read())
+                first = parsed[0]
+                if first.type == "comment" and \
+                    first.value.startswith(json_prefix):
+                    data = first.value.split(json_prefix)[1]
+                    metadata = json.loads(data)
+                    yield metadata

--- a/django_google_fonts/apps.py
+++ b/django_google_fonts/apps.py
@@ -1,13 +1,13 @@
+import hashlib
+import json
 import logging
 import os
 
-import hashlib
 import requests
 import tinycss2
-import json
-from tinycss2.ast import Comment
 from django.apps import AppConfig
 from django.conf import settings
+from tinycss2.ast import Comment
 
 logger = logging.getLogger(__name__)
 # pylint: disable=logging-fstring-interpolation invalid-name
@@ -29,17 +29,22 @@ fonts = []
 
 
 class Font:
-    __slots__ = ["name", "dest", "slug", "dest_css", "rest"]
+    __slots__ = ["name", "dest", "slug", "dest_css", "params"]
 
     def __init__(self, name, dest):
         self.name = name
         lowered = name.replace(" ", "").lower()
         if ":" in lowered:
-            self.slug, rest = lowered.split(":")
-            self.rest = {"original": rest, "hash": hashlib.shake_256(rest.encode("utf-8")).hexdigest(8)}
+            self.slug, params = lowered.split(":")
+            self.params = {
+                "original": params,
+                "hash": hashlib.shake_256(params.encode("utf-8")).hexdigest(8),
+            }
+            self.dest_css = os.path.join(dest, f"{self.slug}-{self.params['hash']}.css")
         else:
             self.slug = lowered
-        self.dest_css = os.path.join(dest, f"{self.slug}-{self.rest['hash']}.css")
+            self.params = {}
+            self.dest_css = os.path.join(dest, f"{self.slug}.css")
         self.dest = dest
 
     def cached(self):
@@ -89,11 +94,9 @@ class Font:
                             f.write(res.content)
 
                         # JSON inside CSS. It's the future.
-                        metadata = json.dumps({
-                            "name": self.name,
-                            "slug": self.slug,
-                            "rest": self.rest
-                        })
+                        metadata = json.dumps(
+                            {"name": self.name, "slug": self.slug, "params": self.params}
+                        )
                         comment = Comment(0, 0, f"{json_prefix}{metadata}")
 
                         # STATIC_URL must have a trailing slash.
@@ -106,6 +109,23 @@ class Font:
 
         with open(self.dest_css, "w", encoding="utf-8") as f:
             f.write(tinycss2.serialize(output_css))
+
+    def metadata(self):
+        metadata = {"files": []}
+        with open(self.dest_css, "r", encoding="utf-8") as f:
+            parsed = tinycss2.parse_stylesheet(f.read())
+            for rule in parsed:
+                if rule.type == "at-rule":
+                    for line in rule.content:
+                        if line.type == "url":
+                            metadata["files"].append(line.value)
+
+            first = parsed[0]
+            if first.type == "comment" and first.value.startswith(json_prefix):
+                data = first.value.split(json_prefix)[1]
+                metadata.update(json.loads(data))
+
+        return metadata
 
 
 class DjangoGoogleFontsConfig(AppConfig):
@@ -149,14 +169,3 @@ class DjangoGoogleFontsConfig(AppConfig):
             self.fonts.append(font)
 
         return True
-
-    def iterate(self):
-        for font in self.fonts:
-            with open(font.dest_css, "r", encoding="utf-8") as f:
-                parsed = tinycss2.parse_stylesheet(f.read())
-                first = parsed[0]
-                if first.type == "comment" and \
-                    first.value.startswith(json_prefix):
-                    data = first.value.split(json_prefix)[1]
-                    metadata = json.loads(data)
-                    yield metadata

--- a/django_google_fonts/templatetags/google_fonts.py
+++ b/django_google_fonts/templatetags/google_fonts.py
@@ -26,3 +26,15 @@ def font_css(name):
                 return data
             except FileNotFoundError:
                 logger.error(f"{log_prefix}: Failed to get find css for font: {name}")
+
+
+@register.simple_tag
+def font_debug():
+    fonts = apps.get_app_config("django_google_fonts").fonts
+    metadata = []
+    for font in fonts:
+        metadata.append({"font": font.name, "metadata": font.metadata()})
+        if not metadata:
+            continue
+
+    return metadata

--- a/django_google_fonts/tests.py
+++ b/django_google_fonts/tests.py
@@ -1,29 +1,32 @@
 import os
 import tempfile
-import unittest 
-
+import unittest
 from unittest.mock import ANY, patch
 
 from django.conf import settings
 from django.test import TestCase
 
+
 class Stub(object):
     def __init__(self, **kwargs):
         self.__dict__.update(kwargs)
 
+
 import django
-settings.configure(Stub(
-    DATABASES={'default': {'ENGINE': 'django.db.backends.sqlite3', 'NAME': ':memory:'}},
-    DEBUG=False,
-    FORCE_SCRIPT_NAME=None,
-    INSTALLED_APPS=['django_google_fonts'],
-    LOGGING=None,
-    LOGGING_CONFIG=None,
-    STATIC_URL='/static/',
-))
+
+settings.configure(
+    Stub(
+        DATABASES={"default": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"}},
+        DEBUG=False,
+        FORCE_SCRIPT_NAME=None,
+        INSTALLED_APPS=["django_google_fonts"],
+        LOGGING=None,
+        LOGGING_CONFIG=None,
+        STATIC_URL="/static/",
+    )
+)
 
 from apps import DjangoGoogleFontsConfig, Font
-
 
 roboto_css = """/* cyrillic-ext */
 @font-face {
@@ -148,5 +151,6 @@ class TestDjangoGoogleFontsConfig(TestCase):
             res = self.obj.ready()
             self.assertEqual(res, True)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
* [x] Hash the value after the font name, so for example: `Lato:wght@100;300;400;700` becomes `lato-907ee0fd106c2c07.css`. Using a smaller hash, like `shake_256` because hash collisions are unlikely and non-critical if they happen.
* [x] Add in a hack to add in data into the CSS so we can figure out where it came from later. JSON in CSS, shudder.
* [x] Add in `font_debug` which dumps useful back to the user.
* [ ] Update the readme and note the backwards incompatibility.
* [ ] Needs some tests
* [ ] Bump the major version

Fixes #3